### PR TITLE
Fix UseDbx prefix handling for trailing slashes

### DIFF
--- a/src/dbx.tests/DbxServiceExtensionsTests.cs
+++ b/src/dbx.tests/DbxServiceExtensionsTests.cs
@@ -54,6 +54,16 @@ public class DbxServiceExtensionsTests
         Assert.AreSame(app, result);
     }
 
+    [TestMethod]
+    public void UseDbx_WithPrefixWithTrailingSlash_RemovesSlash()
+    {
+        // exposes Bug#7; fixed in Release 0.3
+        var prefix = "trailing/slash/";
+        var app = BuildApp();
+        var result = app.UseDbx(prefix); // no error
+
+        Assert.AreSame(app, result);
+    }
 
     private static WebApplication BuildApp()
     {

--- a/src/dbx/DbxServiceExtensions.cs
+++ b/src/dbx/DbxServiceExtensions.cs
@@ -52,7 +52,9 @@ public static class DbxServiceExtensions
 
         var options = app.Services.GetRequiredService<IOptions<DbxOptions>>().Value;
         prefix ??= options.Prefix ?? string.Empty;
-        prefix = string.Join('/', prefix, "dbx");
+        prefix = prefix.EndsWith('/')
+            ? string.Concat(prefix, "dbx")
+            : string.Join('/', prefix, "dbx");
 
         var group = app.MapGroup(prefix);
         // Administrative Endpoints
@@ -78,7 +80,7 @@ public static class DbxServiceExtensions
         group.MapDelete("{id}/{itemId}", (IDbxService dbx, string id, string itemId, CancellationToken cancellationToken)
             => dbx.DeleteItemAsync(id, itemId, cancellationToken));
 
-        app.Logger.LogInformation("{ServiceName} is running at '{Prefix}/'", nameof(DbxService), prefix);
+        app.Logger.LogInformation("{ServiceName}, running, {Prefix}", nameof(DbxService), prefix);
         return app;
     }
 }


### PR DESCRIPTION
Fixes #7 Also Closes #8

Add a unit test to verify UseDbx works with prefixes ending in a slash, addressing Bug#7. Update prefix construction logic to avoid double slashes by concatenating "dbx" directly if the prefix already ends with a slash.