### PR TITLE
Expand Dbx API: add status, list, and bulk read endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,17 @@ All **dbx** api calls return the response object shown above. In the case of suc
 ## Dbx Endpoints
 The following endpoints are available:
 
-| Name | Method | Path | Description |
-| ---- | ------- | ---- | ----------- |
-| status | GET  | `dbx/status/` | Returns the status of the service |
-| create | POST | `dbx/{id}/` | Creates a new item the indicated identifier |
-| list   | GET  | `dbx/{id}/` | Lists items available for the indicated identifier |
-| read   | GET  | `dbx/{id}/{itemId}` | Retrieves an individual item associated with an identifier |
-| update | PUT  | `dbx/{id}/{itemId}` | Replaces an item |
-| update | PATCH| `dbx/{id}/{itemId}` | Replaces some properties of an item |
-| delete |DELETE| `dbx/{id}/{itemId}` | Deletes an item |
+| Name   | Method | Path | Description |
+| ------ | ------ | ---- | ----------- |
+| status | GET    | `dbx/status/`       | Returns the status of the service |
+| status | GET    | `dbx/status/{id}/`  | Returns status, including a count of items, for an identifier |
+| list   | GET    | `dbx/list/{id}/`    | Lists all item ids available for the indicated identifier |
+| create | POST   | `dbx/{id}/`         | Creates a new item the indicated identifier |
+| read   | GET    | `dbx/{id}`          | Reads items with contents, (100 records max per page) | 
+| read   | GET    | `dbx/{id}/{itemId}` | Retrieves an individual item associated with an identifier |
+| update | PUT    | `dbx/{id}/{itemId}` | Replaces an item |
+| update | PATCH  | `dbx/{id}/{itemId}` | Replaces some properties of an item |
+| delete | DELETE | `dbx/{id}/{itemId}` | Deletes an item |
 ### Response Codes
 - **200 Ok** - returned with success response message in the body; data varies
 - **201 Created** - returned with successful response message; ***itemId*** is in the data field

--- a/src/dbx/DbxRepository.cs
+++ b/src/dbx/DbxRepository.cs
@@ -16,6 +16,8 @@ namespace Tudormobile.Dbx;
 internal class DbxRepository
 {
     private readonly string _dataPath;
+    private static readonly SemaphoreSlim _fileSemaphore = new(10);
+    private const int MaxItemsToLoad = 100;  // At class level
 
     /// <summary>
     /// Initializes a new instance of the repository.
@@ -35,6 +37,38 @@ internal class DbxRepository
         // *.json files under the id directory
         => GetIdentifiersAsync(IdDirectory(id), f => Directory.EnumerateFiles(f, "*.json"), cancellationToken);
 
+    public async Task<int> CountAllItemIdentifiersAsync(string id, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        // *.json files under the id directory
+        var identifiers = await GetIdentifiersAsync(IdDirectory(id), f => Directory.EnumerateFiles(f, "*.json"), cancellationToken);
+        return identifiers.Count;
+    }
+
+    public async Task<(string ItemId, JsonElement Data)[]> GetAllItemsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        var dir = IdDirectory(id);
+        if (Directory.Exists(dir))
+        {
+            var itemIds = await GetAllItemIdentifiersAsync(id, cancellationToken);
+
+            var tasks = itemIds.Take(MaxItemsToLoad).Select(async itemId =>
+            {
+                await _fileSemaphore.WaitAsync(cancellationToken);
+                try 
+                { 
+                    var data = await GetItemAsync(id, itemId, cancellationToken);
+                    return (itemId, data);
+                }
+                finally { _fileSemaphore.Release(); }
+            });
+            var items = await Task.WhenAll(tasks);
+            return [.. items.Where(item => item.data.HasValue).Select(item => (item.itemId, item.data!.Value))];
+        }
+        return [];
+    }
+
     public Task<bool> ItemExistsAsync(string id, string itemId, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(id);
@@ -51,8 +85,15 @@ internal class DbxRepository
         var itemFile = ItemIdFile(id, itemId);
         if (File.Exists(itemFile))
         {
-            var json = await File.ReadAllTextAsync(itemFile, cancellationToken);
-            return JsonElement.Parse(json);
+            try
+            {
+                var json = await File.ReadAllTextAsync(itemFile, cancellationToken);
+                return JsonElement.Parse(json);
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
         }
         return null;
     }

--- a/src/dbx/DbxRepository.cs
+++ b/src/dbx/DbxRepository.cs
@@ -40,9 +40,23 @@ internal class DbxRepository
     public async Task<int> CountAllItemIdentifiersAsync(string id, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(id);
-        // *.json files under the id directory
-        var identifiers = await GetIdentifiersAsync(IdDirectory(id), f => Directory.EnumerateFiles(f, "*.json"), cancellationToken);
-        return identifiers.Count;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dir = IdDirectory(id);
+        if (!Directory.Exists(dir))
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var _ in Directory.EnumerateFiles(dir, "*.json"))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            count++;
+        }
+
+        await Task.CompletedTask;
+        return count;
     }
 
     public async Task<(string ItemId, JsonElement Data)[]> GetAllItemsAsync(string id, CancellationToken cancellationToken = default)

--- a/src/dbx/DbxService.cs
+++ b/src/dbx/DbxService.cs
@@ -48,6 +48,16 @@ internal class DbxService : IDbxService
         });
     }
 
+    public Task<DbxResponse> GetIdStatusAsync(string id, CancellationToken cancellationToken = default)
+    {
+        LogApiRequest();
+        return ExecuteAsync(async () =>
+        {
+            int count = await _repository.CountAllItemIdentifiersAsync(id, cancellationToken);
+            return (object?)new { id, count, };
+        });
+    }
+
     /// <inheritdoc/>
     public Task<DbxResponse> CreateItemAsync(string id, JsonElement content, CancellationToken cancellationToken = default)
     {
@@ -65,6 +75,17 @@ internal class DbxService : IDbxService
     {
         LogApiRequest();
         return ExecuteAsync(async () => (object?)await _repository.GetAllItemIdentifiersAsync(id, cancellationToken));
+    }
+
+    /// <inheritdoc/>
+    public Task<DbxResponse> GetItemsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        LogApiRequest();
+        return ExecuteAsync(async () =>
+        {
+            var items = await _repository.GetAllItemsAsync(id, cancellationToken);
+            return (object?)items.ToDictionary(item => item.ItemId, item => item.Data);
+        });
     }
 
     /// <inheritdoc/>

--- a/src/dbx/DbxServiceExtensions.cs
+++ b/src/dbx/DbxServiceExtensions.cs
@@ -61,12 +61,19 @@ public static class DbxServiceExtensions
         group.MapGet("status", (IDbxService dbx, CancellationToken cancellationToken)
             => dbx.GetStatusAsync(cancellationToken));
 
+        group.MapGet("status/{id}", (IDbxService dbx, string id, CancellationToken cancellationToken)
+            => dbx.GetIdStatusAsync(id, cancellationToken));
+
+        // Identifier endpoints
+        group.MapGet("list/{id}", (IDbxService dbx, string id, CancellationToken cancellationToken)
+            => dbx.ListItemsAsync(id, cancellationToken));
+
+        group.MapGet("{id}", (IDbxService dbx, string id, CancellationToken cancellationToken)
+            => dbx.GetItemsAsync(id, cancellationToken));
+
         // CRUD Endpoints
         group.MapPost("{id}", (IDbxService dbx, string id, [FromBody] JsonElement content, CancellationToken cancellationToken)
             => dbx.CreateItemAsync(id, content, cancellationToken));
-
-        group.MapGet("{id}", (IDbxService dbx, string id, CancellationToken cancellationToken)
-            => dbx.ListItemsAsync(id, cancellationToken));
 
         group.MapGet("{id}/{itemId}", (IDbxService dbx, string id, string itemId, CancellationToken cancellationToken)
             => dbx.GetItemAsync(id, itemId, cancellationToken));

--- a/src/dbx/IDbxService.cs
+++ b/src/dbx/IDbxService.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
-using System.Text.Json;
+﻿using System.Text.Json;
 
 namespace Tudormobile.Dbx;
 
@@ -29,7 +28,7 @@ public interface IDbxService
     /// </summary>
     /// <param name="id">The collection identifier (64 lowercase hex characters).</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-    /// <returns>A <see cref="DbxResponse"/> containing the identifer status including the item count.</returns>
+    /// <returns>A <see cref="DbxResponse"/> containing the identifier status including the item count.</returns>
     Task<DbxResponse> GetIdStatusAsync(string id, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/dbx/IDbxService.cs
+++ b/src/dbx/IDbxService.cs
@@ -25,13 +25,13 @@ public interface IDbxService
     Task<DbxResponse> GetStatusAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Creates a new item in the specified collection with a generated identifier.
+    /// Retrieves the identifier status, including the item count.
     /// </summary>
     /// <param name="id">The collection identifier (64 lowercase hex characters).</param>
-    /// <param name="content">The JSON content to store as the item.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-    /// <returns>A <see cref="DbxResponse"/> whose <c>Data</c> property contains the new item identifier if successful.</returns>
-    Task<DbxResponse> CreateItemAsync(string id, JsonElement content, CancellationToken cancellationToken = default);
+    /// <returns>A <see cref="DbxResponse"/> containing the identifer status including the item count.</returns>
+    Task<DbxResponse> GetIdStatusAsync(string id, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Lists all item identifiers in the specified collection.
     /// </summary>
@@ -39,6 +39,23 @@ public interface IDbxService
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="DbxResponse"/> whose <c>Data</c> property contains a list of item identifiers.</returns>
     Task<DbxResponse> ListItemsAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves all items in the specified collection.
+    /// </summary>
+    /// <param name="id">The collection identifier (64 lowercase hex characters).</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="DbxResponse"/> whose <c>Data</c> property contains a list of items.</returns>
+    Task<DbxResponse> GetItemsAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new item in the specified collection with a generated identifier.
+    /// </summary>
+    /// <param name="id">The collection identifier (64 lowercase hex characters).</param>
+    /// <param name="content">The JSON content to store as the item.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="DbxResponse"/> whose <c>Data</c> property contains the new item identifier if successful.</returns>
+    Task<DbxResponse> CreateItemAsync(string id, JsonElement content, CancellationToken cancellationToken = default);
     /// <summary>
     /// Retrieves a specific item from the specified collection.
     /// </summary>

--- a/src/host/host.http
+++ b/src/host/host.http
@@ -4,6 +4,15 @@ GET {{dbx_HostAddress}}/api/v1/dbx/status
 Accept: application/json
 
 ###
+GET {{dbx_HostAddress}}/api/v1/dbx/status/test
+Accept: application/json
+
+###
+GET {{dbx_HostAddress}}/api/v1/dbx/list/test
+Accept: application/json
+
+###
+
 GET {{dbx_HostAddress}}/api/v1/dbx/test/
 Accept: application/json
 


### PR DESCRIPTION
Closes #10 Closes #11
- Add endpoints for collection status with item count, listing all item IDs, and retrieving all items (up to 100 per request)
- Update repository and service layers to support counting and bulk retrieval of items
- Update IDbxService interface and endpoint mappings for new features
- Revise README and host.http to document and demonstrate new endpoints
- Improves API clarity, efficiency, and documentation